### PR TITLE
Fix config.particalSize not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import React from 'react';
 import useLoadPCD from 'useloadpcd';
 
 const App = () => {
-    const [pcdRef, status] = useLoadPCD('./simple.pcd');
+    const [pcdRef, status] = useLoadPCD('./simple.pcd', {});
 
     return <div ref={pcdRef} style={{ width: 800, height: 800 }} />;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const load = (
                         );
                     }
 
-                    (sceneStyle as any).material.size = 0.1;
+                    (sceneStyle as any).material.size = config.particalSize
 
                     if (canvas.current !== null) {
                         canvas.current.appendChild(renderer.domElement);


### PR DESCRIPTION
- Fix: `config.particalSize` not works
- Fix: add missing `config` param in README, which causes typescript warning. 